### PR TITLE
sonarQubeProperties excludes JFrames from coverage report (still analyzes them)

### DIFF
--- a/AlimentacionSaludable/.scannerwork/report-task.txt
+++ b/AlimentacionSaludable/.scannerwork/report-task.txt
@@ -2,5 +2,5 @@ projectKey=obligatorioIS2
 serverUrl=http://localhost:9000
 serverVersion=8.2.0.32929
 dashboardUrl=http://localhost:9000/dashboard?id=obligatorioIS2
-ceTaskId=AXFYFDKABJC6UpevKyRB
-ceTaskUrl=http://localhost:9000/api/ce/task?id=AXFYFDKABJC6UpevKyRB
+ceTaskId=AXFwvi50LaC63WGlVFS6
+ceTaskUrl=http://localhost:9000/api/ce/task?id=AXFwvi50LaC63WGlVFS6

--- a/AlimentacionSaludable/build/built-jar.properties
+++ b/AlimentacionSaludable/build/built-jar.properties
@@ -1,4 +1,4 @@
-#Wed, 08 Apr 2020 01:35:51 -0300
+#Wed, 08 Apr 2020 01:54:25 -0300
 
 
 C\:\\Users\\matia\\Desktop\\ID2\\AlimentacionSaludable=

--- a/AlimentacionSaludable/sonar-project.propierties.cfg
+++ b/AlimentacionSaludable/sonar-project.propierties.cfg
@@ -13,6 +13,7 @@ sonar.projectVersion=1.0
 sonar.sources=\src
 sonar.java.binaries=\dist
 
+sonar.coverage.exclusions=\src\interfaz\
  
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Modifications to sonar-project.properties to exclude sources from UI java classes